### PR TITLE
feat: Remove upper limit for IntelliJ Platform version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ pluginVersion = 2.4.7
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213
-pluginUntilBuild = 233.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
The changes in this commit remove the `pluginUntilBuild` property from the
`gradle.properties` file. This property was used to limit the compatibility of
the plugin to a specific range of IntelliJ Platform versions. By removing this
property, the plugin will now be compatible with all future versions of the
IntelliJ Platform, making it more future-proof and easier to maintain.

Increases the plugin version from 2.4.7 to 2.4.8 in the gradle.properties file.
This is a minor version increase as it includes new features or improvements,
but no breaking changes.

fixes: https://github.com/nEdAy/Flutter-Toolkit/issues/24